### PR TITLE
update capstone to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Ted Mielczarek <ted@mielczarek.org>"]
 
 [dependencies]
 addr2line = "0.7.0"
-capstone = "0.2.0"
+capstone = "0.5.0"
 failure = "0.1.1"
 memmap = "0.6.1"
 moria = { git = "https://github.com/gimli-rs/moria/", rev = "ed6d27570126e0b2b90db54bc45b5514e5918bdf"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ pub fn disasm_bytes(bytes: &[u8],
         Color::No => false,
     };
     let mut source_lines = HashMap::new();
-    let cs = Capstone::new_raw(arch, mode, NO_EXTRA_MODE, None)?;
+    let mut cs = Capstone::new_raw(arch, mode, NO_EXTRA_MODE, None)?;
     let mut last_loc: Option<SourceLocation> = None;
     let mut buf = vec![];
     let mut stdout = io::stdout();


### PR DESCRIPTION
The changelogs for `capstone-sys` and `capstone` don't discuss any specific new disassembler support, but newer seems better than older in this case.